### PR TITLE
Upgrade to second version with more Command Line Utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+0.1.1
+[ not for production ]
+- Add support for custom port when serving files
+- Add a cmd line utility `dipor bigbang [appname]` for minimal working playground
+- Add a cmd line utility for hard build `dipor build [serve]`
+- Add a cmd line utility for soft build `dipor dev [serve]`
+- Update `dipor use <github-link>` for using themes
+- Add a cmd line utility `dipor serve` to serve `public/` without running build
+- Update `dipor_settings` path
+
+0.1.0
+[ not for production ]
+- The initial _not for production_ release

--- a/dipor/cmd/start.py
+++ b/dipor/cmd/start.py
@@ -176,18 +176,21 @@ class EntryPointCommands:
         # serve.....done
 
     def default_action(self, *args, **kwargs):
+        '''
+        to be filled
+        '''
         print("running default action")
 
     def use_theme(self, *args, **kwargs):
         print("running use theme")
-        print(args)
         app_name = ""
         if args[0]:
             git_path = args[0][0]
             if len(args[0]) >= 2:
                 app_name = args[0][1]
-            print(f"git clone --quiet {git_path} {app_name}")
             os.system(f"git clone --quiet {git_path} {app_name}")
+            git_path = os.path.join(self.dst_root, app_name, ".git")
+            shutil.rmtree(git_path)
         else:
             print("Need a git Path")
 

--- a/dipor/cmd/start.py
+++ b/dipor/cmd/start.py
@@ -6,15 +6,8 @@ import dipor
 from dipor.main import builder_main
 from dipor.server import runserver
 
-'''
-MAIN FUNCTIONS -
-    - quickstart (the default template)
-    - bigbang (nothing is set just the src/content directories/settings)
-    - use <github-src> (to use themes from github)
-    - dipor dev [-PORT]
-    - dipor build [-NOSERVE]
-    - help (?)
-'''
+DEFAULT_PORT = 5050
+
 class EntryPointCommands:
 
     def __init__(self, args):
@@ -22,7 +15,8 @@ class EntryPointCommands:
                         'bigbang': self.bigbang,
                         'use': self.use_theme,
                         'dev': self.soft_build,
-                        'build': self.hard_build}
+                        'build': self.hard_build,
+                        'serve': self.serve_public}
 
         self.src_root = self.get_src_root
         self.dst_root = self.get_dst_root
@@ -103,6 +97,7 @@ class EntryPointCommands:
             'DIPOR_INITIAL_APP': '"/"',
             'DIPOR_EXTENSIONS': "['meta']",
             'DIPOR_FILE_FORMATS_ALLOWED': "['md', 'json']",
+            'DIPOR_PORT': f"{DEFAULT_PORT}",
             'DIPOR_PRETTIFY': "True"
         }
 
@@ -132,7 +127,7 @@ class EntryPointCommands:
         }
         self.generate_settings(app_name, settings)
         print("Building the /public repo")
-        self.build_public(os.path.join(self.dst_root, app_name, 'src'), os.path.join(self.dst_root, app_name, 'content'), os.path.join(self.dst_root, app_name, 'settings.py'), os.path.join(self.dst_root, app_name, 'public'))
+        self.build_public(os.path.join(self.dst_root, app_name, 'src'), os.path.join(self.dst_root, app_name, 'content'), os.path.join(self.dst_root, app_name, 'dipor_settings.py'), os.path.join(self.dst_root, app_name, 'public'))
         self.serve_public(app_name)
 
     def bigbang(self, *args, **kwargs):
@@ -154,25 +149,31 @@ class EntryPointCommands:
         }
         self.generate_settings(app_name, settings)
         print("Building the /public repo")
-        self.build_public(os.path.join(self.dst_root, app_name, 'src'), os.path.join(self.dst_root, app_name, 'content'), os.path.join(self.dst_root, app_name, 'settings.py'), os.path.join(self.dst_root, app_name, 'public'))
+        self.build_public(os.path.join(self.dst_root, app_name, 'src'), os.path.join(self.dst_root, app_name, 'content'), os.path.join(self.dst_root, app_name, 'dipor_settings.py'), os.path.join(self.dst_root, app_name, 'public'))
         self.serve_public(app_name)
 
 
     def soft_build(self, *args, **kwargs):
         print("running dev")
-        self.build_public(os.path.join(self.dst_root, 'src'), os.path.join(self.dst_root, 'content'), os.path.join(self.dst_root, 'settings.py'), os.path.join(self.dst_root, 'public'))
+        self.build_public(os.path.join(self.dst_root, 'src'), os.path.join(self.dst_root, 'content'), os.path.join(self.dst_root, 'dipor_settings.py'), os.path.join(self.dst_root, 'public'))
         if args[0]:
             if args[0][0] == "serve":
                 self.serve_public('')
 
     def hard_build(self, *args, **kwargs):
         print("running build")
-        # clean the public folder
-        # get the directories
-        # convert to public
+        shutil.rmtree(os.path.join(self.dst_root, 'public'))
+        self.build_public(os.path.join(self.dst_root, 'src'), os.path.join(self.dst_root, 'content'), os.path.join(self.dst_root, 'dipor_settings.py'), os.path.join(self.dst_root, 'public'))
+        if args[0]:
+            if args[0][0] == "serve":
+                self.serve_public('')
+        
+        # clean the public folder......done
+        # get the directories.....done
+        # convert to public.....done
         # do post-processing (prettify/compress/make static easily available)
         # do an accessibility check
-        # serve
+        # serve.....done
 
     def default_action(self, *args, **kwargs):
         print("running default action")
@@ -200,8 +201,9 @@ class EntryPointCommands:
         '''
         builder_main(src_path, content_path, settings_path, public_folder)
 
-    def serve_public(self, app_name):
-        runserver(app_name)
+    def serve_public(self, *args, app_name='', port=DEFAULT_PORT):
+        settings_path = os.path.join(self.dst_root, 'dipor_settings.py')
+        runserver(app_name, settings_path)
 
 def main():
     '''

--- a/dipor/cmd/start.py
+++ b/dipor/cmd/start.py
@@ -157,18 +157,13 @@ class EntryPointCommands:
         self.build_public(os.path.join(self.dst_root, app_name, 'src'), os.path.join(self.dst_root, app_name, 'content'), os.path.join(self.dst_root, app_name, 'settings.py'), os.path.join(self.dst_root, app_name, 'public'))
         self.serve_public(app_name)
 
-        # create src
-        # create content
-        # create settings
-        # create a hello dipor barren page
-        # build to create single page
-
 
     def soft_build(self, *args, **kwargs):
         print("running dev")
-        # get the content
-        # get the src
-        # convert to public
+        self.build_public(os.path.join(self.dst_root, 'src'), os.path.join(self.dst_root, 'content'), os.path.join(self.dst_root, 'settings.py'), os.path.join(self.dst_root, 'public'))
+        if args[0]:
+            if args[0][0] == "serve":
+                self.serve_public('')
 
     def hard_build(self, *args, **kwargs):
         print("running build")

--- a/dipor/cmd/start.py
+++ b/dipor/cmd/start.py
@@ -141,14 +141,19 @@ class EntryPointCommands:
             app_name = args[0][0]
             
         print("running bigbang")
-        os.mkdir(os.path.join(self.dst_root, app_name, 'src'))
-        os.mkdir(os.path.join(self.dst_root, app_name, 'content'))
+        print("Getting the /src directory...")
+        starters_route = os.path.join('starters', 'bigbang')
+        self.copy_tree(os.path.join(self.src_root, starters_route), os.path.join(self.dst_root, app_name), 'src')
+        print("Getting the /content directory...")
+        self.copy_tree(os.path.join(self.src_root, starters_route), os.path.join(self.dst_root, app_name), 'content')
+        print("Getting the settings file...")
         settings = {
             'DIPOR_SOURCE_ROOT': f"'{os.path.join(app_name, 'src')}'",
             'DIPOR_CONTENT_ROOT': f"'{os.path.join(app_name, 'content')}'",
             'DIPOR_INITIAL_APP': f"'{app_name}'"
         }
         self.generate_settings(app_name, settings)
+        print("Building the /public repo")
         self.build_public(os.path.join(self.dst_root, app_name, 'src'), os.path.join(self.dst_root, app_name, 'content'), os.path.join(self.dst_root, app_name, 'settings.py'), os.path.join(self.dst_root, app_name, 'public'))
         self.serve_public(app_name)
 

--- a/dipor/server.py
+++ b/dipor/server.py
@@ -3,11 +3,18 @@ import socketserver
 from os import listdir
 import os
 import pathlib
+import sys
 import webbrowser
 
-PORT = 5050
 
-def runserver(app_name):
+def runserver(app_name, settings_path):
+    sys.path.append(os.path.dirname(settings_path))
+    print(settings_path)
+    import dipor_settings
+    settings_tmp = dipor_settings.instance
+    settings = { key: settings_tmp[key] for key in settings_tmp.keys() if key.startswith("DIPOR_")}
+    print(settings)
+    PORT = settings['DIPOR_PORT']
     web_dir = os.path.join(pathlib.Path().absolute(), app_name, 'public')
     os.chdir(web_dir)
     class CustomHttpRequestHandler(http.server.SimpleHTTPRequestHandler):            

--- a/dipor/starters/bigbang/content/common.md
+++ b/dipor/starters/bigbang/content/common.md
@@ -1,0 +1,3 @@
+name: Dipor
+
+This is the very beginning, the bigbang of your awesome sauce project.

--- a/dipor/starters/bigbang/src/index.html
+++ b/dipor/starters/bigbang/src/index.html
@@ -1,0 +1,5 @@
+Hello {{ common.name }}!
+
+<p>
+{{ common.content }}
+</p>


### PR DESCRIPTION
[ not for production ]
- Add support for custom port when serving files
- Add a cmd line utility `dipor bigbang [appname]` for minimal working playground
- Add a cmd line utility for hard build `dipor build [serve]`
- Add a cmd line utility for soft build `dipor dev [serve]`
- Update `dipor use <github-link>` for using themes
- Add a cmd line utility `dipor serve` to serve `public/` without running build
- Update `dipor_settings` path